### PR TITLE
handle extra playoffs tr, add result to uid

### DIFF
--- a/app/api/tkers/lib.ts
+++ b/app/api/tkers/lib.ts
@@ -31,6 +31,10 @@ export async function getScheduleEventsForTeamId(
   const splitEvents: LeagueLabEvent[] = [];
   scheduleTable.children().each((i, el) => {
     const $tr = $html(el);
+    if ($tr.text().trim() === "PLAYOFFS") {
+      logger.debug(`${i}: ${$tr} - discarding playoffs banner row`);
+      return;
+    }
 
     const event: LeagueLabEvent = {
       teamId,
@@ -86,6 +90,8 @@ export async function getAllScheduleEvents(): Promise<ics.IcsEvent[]> {
 }
 
 export function mapToIcsEvent(event: LeagueLabEvent): ics.IcsEvent {
+  const uid = `${event.gameId ?? `${event.teamId}-${event.date}-${event.time}`}-${event.result?.replaceAll("\n", "")}`;
+
   const start = getStartDateTime(event);
   const startObject: ics.IcsDateObject = {
     date: start,
@@ -103,7 +109,7 @@ export function mapToIcsEvent(event: LeagueLabEvent): ics.IcsEvent {
 
   const result: ics.IcsEvent = {
     summary: `${event.teamName} vs ${event.opponent} @ ${event.location} - ${event.field}`,
-    uid: event.gameId ?? `${event.teamId}-${event.date}-${event.time}`,
+    uid: uid,
     stamp: startObject,
     start: startObject,
     duration: { hours: 1 },


### PR DESCRIPTION
This pull request makes targeted improvements to how schedule events are processed and exported, focusing on filtering out irrelevant rows and enhancing the uniqueness of event identifiers in the iCalendar export.

Event filtering and processing:

* Updated the `getScheduleEventsForTeamId` function to skip rows in the schedule table that are playoff banners, preventing non-event rows from being processed as events.

iCalendar (ICS) export enhancements:

* Improved the uniqueness of the `uid` field in the `mapToIcsEvent` function by including the event result (with newlines removed) in the generated UID, reducing the chance of duplicate identifiers in the exported calendar. [[1]](diffhunk://#diff-afe51ab8beba78c3fc32b922e9d7d2fad7750c006479142c1efed067c973883aR93-R94) [[2]](diffhunk://#diff-afe51ab8beba78c3fc32b922e9d7d2fad7750c006479142c1efed067c973883aL106-R112)